### PR TITLE
Private/pedro/stand ubuntu events list

### DIFF
--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -148,7 +148,7 @@ showcase: |
     body {
       color: #111111;
     }
-    .jumbotron {
+    .jumbotron, .badge-primary {
       background-color: #E95420;
       color: #fff
     }

--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -155,6 +155,9 @@ showcase: |
     .card {
       border-color: #E95420;
     }
+    .card .badge {
+      line-height: 1.4;
+    }
 
     a:link {
       color: #06c;

--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -25,13 +25,36 @@ description: |
 showcase: |
 
   <h3>Live events (WIP)</h3>
-  <ul>
-    <li>
-      Saturday, February 5, 1:00 PM (CET):<br>
-      Contributing to Open Source Projects with Ubuntu, Nextcloud, and Collabora, by PS</li>
-    <li>
-      Sunday, February 6, x:00 PM (CET):<br>
-      Setting up a Nextcloud Instance with Collabora on Ubuntu
+  <ul class="list-group list-group-horizontal">
+    <li class="list-group-item">
+      <h4>Saturday, February 5</h4>
+      <div class="card">
+        <div class="card-body">
+          <p class="badge badge-pill badge-primary">1:00 PM (CET)</p>
+          <h5 class="card-title"><span class="material-icons md-18 mr-1">favorite</span>Contributing to Open Source Projects with Ubuntu, Nextcloud, and Collabora</h5>
+          <p class="card-text">
+            Some quick example text to build on the card title
+            and make up the bulk of the card's content by PS.
+          </p>
+          <!--<a href="#" class="card-link">Card link</a>
+          <a href="#" class="card-link">Another link</a>-->
+        </div>
+      </div>
+    </li>
+    <li class="list-group-item">
+      <h4>Sunday, February 6</h4>
+      <div class="card">
+        <div class="card-body">
+        <p class="badge badge-pill badge-primary">X:00 PM (CET)</p>
+          <h5 class="card-title"><span class="material-icons md-18 mr-1">build</span>Setting up a Nextcloud Instance with Collabora on Ubuntu</h5>
+          <p class="card-text">
+            Some quick example text to build on the card title
+            and make up the bulk of the card's content by Speaker(s).
+          </p>
+          <!--<a href="#" class="card-link">Card link</a>
+          <a href="#" class="card-link">Another link</a>-->
+        </div>
+      </div>
     </li>
   </ul>
 


### PR DESCRIPTION
commit 43a54354b1954cc12b4ebf3e43e25e06235296fa
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Jan 28 11:30:55 2022 +0100

    Ubuntu stand: Increase space around badge text
    
    by fixing its line height (default values were suboptimal)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>


commit 0cbf2ddd37e25a6873a1ee80aa86230163626548
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Jan 28 11:13:26 2022 +0100

    Ubuntu stand: Avoid blue primary badges
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

commit 951877a3f383630dda147e6da85d45a4c69f1c88
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Jan 28 11:09:07 2022 +0100

    Ubuntu stand: Add information hierarchy to the events
    
    Allow for easier scannability by handling time and dates as main elms
    of the list and let the events to surface as cards
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

![image](https://user-images.githubusercontent.com/65948705/151532218-673ceca6-f502-4181-a62b-06967ed2259b.png)

