### PR TITLE
Ubuntu stand: Change event list direction when on mobile

### DIFF
--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -165,6 +165,12 @@ showcase: |
     a:visited {
       color: #772953;
     }
+    @media (max-width:767px) {
+      .list-group-horizontal {
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
   </style>
 
   <script>


### PR DESCRIPTION
or in any screen that is too small for that matter

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

<table>
<tr><td><img src="https://user-images.githubusercontent.com/65948705/151537742-b93cceb5-41c0-4bbf-871f-07c05fd045d2.png" width="411"></td></tr></table><table>
<tr><td><img src="https://user-images.githubusercontent.com/65948705/151537755-da6ac08c-e782-48f6-94c5-6feca45efeda.png"></td></tr>
</table>