### PR TITLE
Ubuntu stand: Use smaller size list for events

### DIFF
--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -25,7 +25,7 @@ description: |
 showcase: |
 
   <h3>Live events (WIP)</h3>
-  <ul class="list-group list-group-horizontal">
+  <ul class="list-group list-group-horizontal-md">
     <li class="list-group-item">
       <h4>Saturday, February 5</h4>
       <div class="card">


### PR DESCRIPTION
So it converts well on small screens

<table>
<tr><td><img src="https://user-images.githubusercontent.com/65948705/151537742-b93cceb5-41c0-4bbf-871f-07c05fd045d2.png" width="411"></td></tr></table><table>
<tr><td><img src="https://user-images.githubusercontent.com/65948705/151537755-da6ac08c-e782-48f6-94c5-6feca45efeda.png"></td></tr>
</table>