### PR TITLE
Private/pedro/design improvements

### DIFF
--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -149,6 +149,7 @@ showcase: |
       background: url('/stands/ubuntu/ubuntu-logo14.png') no-repeat center/contain #dd4814;
       color: transparent;
       height: 243px;
+      margin-bottom: 0;
       }
     .badge-primary {
       background-color: #E95420;

--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -160,6 +160,9 @@ showcase: |
     .card .badge {
       line-height: 1.4;
     }
+    #stand-at-fosdem {
+      border-color: #333333;
+    }
 
     a:link {
       color: #06c;

--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -145,7 +145,12 @@ showcase: |
     body {
       color: #111111;
     }
-    .jumbotron, .badge-primary {
+    .jumbotron {
+      background: url('/stands/ubuntu/ubuntu-logo14.png') no-repeat center/contain #dd4814;
+      color: transparent;
+      height: 243px;
+      }
+    .badge-primary {
       background-color: #E95420;
       color: #fff
     }

--- a/content/stands/ubuntu.md
+++ b/content/stands/ubuntu.md
@@ -163,6 +163,9 @@ showcase: |
     #stand-at-fosdem {
       border-color: #333333;
     }
+    #stand-at-fosdem .list-group-item {
+      padding-left: 0;
+    }
 
     a:link {
       color: #06c;


### PR DESCRIPTION
commit a26f1c7999b67fd4c16ecf913a210efc41728b28
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Jan 31 09:48:28 2022 +0100

    Ubuntu stand: Fix header surrounding white space
    
    Context: space from top and space from bottom were not consistent
     - remove bottom margin.

commit 0ccdb14a2119c297e74b4b26077c94a664c1137d
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Jan 31 09:43:54 2022 +0100

    Ubuntu stand: Fix nav card's content alignment
    
    to make sure everything is properly left aligned

commit 7e281782f794bb22ebde376ca91c49969bf3836d
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Jan 31 09:37:59 2022 +0100

    Ubuntu stand: Differentiate nav card from default card
    
    To avoid having cards holding different information type while
    looking too similar to each other

commit db149f46987392455890320c02ba06a694994afe
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Jan 31 09:35:35 2022 +0100

    Ubuntu stand: Use logo as a page header
